### PR TITLE
feat: Add ephemeral port detection for HCX migration

### DIFF
--- a/avs_rvtools_analyzer/risk_detection.py
+++ b/avs_rvtools_analyzer/risk_detection.py
@@ -244,6 +244,7 @@ def detect_oracle_vms(excel_data: pd.ExcelFile) -> Dict[str, Any]:
         <li>Allow Promiscuous mode enabled</li>
         <li>Mac Changes enabled</li>
         <li>Forged Transmits enabled</li>
+        <li>Ephemeral binding: VMs will be migrated with NIC being disconnected</li>
     </ul>"""
 )
 def detect_dvport_issues(excel_data: pd.ExcelFile) -> Dict[str, Any]:
@@ -262,11 +263,12 @@ def detect_dvport_issues(excel_data: pd.ExcelFile) -> Dict[str, Any]:
         vlan_is_null |
         (dvport_data['Allow Promiscuous'].astype(str).str.lower() == 'true') |
         (dvport_data['Mac Changes'].astype(str).str.lower() == 'true') |
-        (dvport_data['Forged Transmits'].astype(str).str.lower() == 'true')
+        (dvport_data['Forged Transmits'].astype(str).str.lower() == 'true') |
+        (dvport_data['Type'].astype(str).str.lower() == 'ephemeral')
     )
 
     # Return original values directly
-    columns_to_return = ['Port', 'Switch', 'Object ID', 'VLAN', 'Allow Promiscuous', 'Mac Changes', 'Forged Transmits']
+    columns_to_return = ['Port', 'Switch', 'Object ID', 'VLAN', 'Allow Promiscuous', 'Mac Changes', 'Forged Transmits', 'Type']
     available_columns = [col for col in columns_to_return if col in dvport_data.columns]
 
     issues = dvport_data[mask][available_columns].to_dict(orient='records')

--- a/tests/create_test_data.py
+++ b/tests/create_test_data.py
@@ -247,17 +247,18 @@ def create_comprehensive_test_data():
     sheets_data['dvPort'] = pd.DataFrame({
         'VM': [
             'vm-web-server-01', 'vm-db-oracle-01', 'vm-risky-port-01', 'vm-risky-port-02',
-            'vm-app-server-01', 'vm-security-risk-01', 'vm-baseline-good'
+            'vm-app-server-01', 'vm-security-risk-01', 'vm-ephemeral-risk-01', 'vm-ephemeral-risk-02', 'vm-baseline-good'
         ],
-        'Port': ['50000001', '50000002', '50000003', '50000004', '50000005', '50000006', '50000007'],
-        'Switch': ['dvSwitch-01'] * 7,
-        'Object ID': ['1001', '1002', '1003', '1004', '1005', '1006', '1007'],
-        'VLAN': [100, None, 200, None, 300, 400, 500],  # Null VLANs (risk)
-        'Allow Promiscuous': ['False', 'True', 'False', 'False', 'False', 'True', 'False'],  # Promiscuous mode (risk)
-        'Mac Changes': ['False', 'False', 'True', 'False', 'False', 'True', 'False'],  # MAC changes (risk)
-        'Forged Transmits': ['False', 'True', 'False', 'True', 'False', 'True', 'False'],  # Forged transmits (risk)
-        'Connected': [True, True, False, True, True, True, True],
-        'Status': ['Connected', 'Connected', 'Disconnected', 'Connected', 'Connected', 'Connected', 'Connected']
+        'Port': ['50000001', '50000002', '50000003', '50000004', '50000005', '50000006', '50000007', '50000008', '50000009'],
+        'Switch': ['dvSwitch-01'] * 9,
+        'Object ID': ['1001', '1002', '1003', '1004', '1005', '1006', '1007', '1008', '1009'],
+        'Type': ['static', 'static', 'ephemeral', 'ephemeral', 'static', 'static', 'ephemeral', 'ephemeral', 'static'],  # Ephemeral types (HCX migration risk)
+        'VLAN': [100, None, 200, None, 300, 400, 500, 600, 700],  # Null VLANs (risk)
+        'Allow Promiscuous': ['False', 'True', 'False', 'False', 'False', 'True', 'False', 'False', 'False'],  # Promiscuous mode (risk)
+        'Mac Changes': ['False', 'False', 'True', 'False', 'False', 'True', 'False', 'False', 'False'],  # MAC changes (risk)
+        'Forged Transmits': ['False', 'True', 'False', 'True', 'False', 'True', 'False', 'False', 'False'],  # Forged transmits (risk)
+        'Connected': [True, True, False, True, True, True, True, True, True],
+        'Status': ['Connected', 'Connected', 'Disconnected', 'Connected', 'Connected', 'Connected', 'Connected', 'Connected', 'Connected']
     })
 
     # vCD sheet - for CD-ROM device risks

--- a/tests/test_individual_risks.py
+++ b/tests/test_individual_risks.py
@@ -281,10 +281,16 @@ class TestDVPortRiskDetection:
         promiscuous_issues = [issue for issue in dvport_issues if str(issue.get('Allow Promiscuous', '')).lower() == 'true']
         mac_change_issues = [issue for issue in dvport_issues if str(issue.get('Mac Changes', '')).lower() == 'true']
         forged_transmit_issues = [issue for issue in dvport_issues if str(issue.get('Forged Transmits', '')).lower() == 'true']
+        ephemeral_issues = [issue for issue in dvport_issues if str(issue.get('Type', '')).lower() == 'ephemeral']
 
         assert len(promiscuous_issues) > 0, "Should find promiscuous mode issues"
         assert len(mac_change_issues) > 0, "Should find MAC change issues"
         assert len(forged_transmit_issues) > 0, "Should find forged transmit issues"
+        assert len(ephemeral_issues) > 0, "Should find ephemeral port type issues"
+        
+        # Verify that all dvPort results include the Type column
+        for issue in dvport_issues:
+            assert 'Type' in issue, "All dvPort results should include Type column"
 
 
 class TestNonIntelHostRiskDetection:


### PR DESCRIPTION
Enhanced dvPort risk detection to identify ephemeral binding types that cause NIC disconnection during HCX migration. Updated tests and alert messages to include HCX compatibility warnings.

Fix #8