### PR TITLE
Fix: #30 – Esx Versions cannot be submitted for an AI suggestion

### DIFF
--- a/tests/test_individual_risks.py
+++ b/tests/test_individual_risks.py
@@ -44,13 +44,14 @@ class TestESXVersionRiskDetection:
 
         assert result["count"] > 0, "Should detect ESX version issues"
         assert "data" in result
-        assert isinstance(result["data"], dict)
+        assert isinstance(result["data"], list)
 
         # Should find old versions like 6.5.0 and 6.7.0
         version_data = result["data"]
+        version_strings = [item["ESX Version"] for item in version_data]
         assert any(
             "6.5.0" in str(version) or "6.7.0" in str(version)
-            for version in version_data.keys()
+            for version in version_strings
         )
 
     def test_detect_esx_versions_structure(self, comprehensive_excel_data):


### PR DESCRIPTION
## Description
Fix the detect_esx_versions function to return data in the same List[Dict] format as other functions

Also removed the specific templating code for this specific risk.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Risk Detection Changes (if applicable)
- [x] Existing risk detection modified

## Testing
- [x] Tests pass locally
- [x] Manual testing completed

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
